### PR TITLE
feat: メッセージ返信向けインターフェースの実装 #28

### DIFF
--- a/src/components/EmailReplyResult.tsx
+++ b/src/components/EmailReplyResult.tsx
@@ -25,15 +25,17 @@ interface EmailReplyResultProps {
   onHistorySelect: (entry: HistoryEntry) => void;
   onTextAdjustment: (customPrompt: string) => void;
   isAdjusting: boolean;
+  mode?: "email" | "message"; // Add mode prop
 }
 
-const EmailReplyResult = ({ 
-  subject, 
-  content, 
-  onReset, 
-  onHistorySelect, 
-  onTextAdjustment, 
-  isAdjusting 
+const EmailReplyResult = ({
+  subject,
+  content,
+  onReset,
+  onHistorySelect,
+  onTextAdjustment,
+  isAdjusting,
+  mode = "email"
 }: EmailReplyResultProps) => {
   const { toast } = useToast();
   const [isSubjectCopied, setIsSubjectCopied] = useState(false);
@@ -122,7 +124,9 @@ const EmailReplyResult = ({
     return (
       <Card className="w-full h-full">
         <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle className="text-xl">生成されたメール</CardTitle>
+          <CardTitle className="text-xl">
+            {mode === "message" ? "生成されたメッセージ" : "生成されたメール"}
+          </CardTitle>
           {history.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -145,7 +149,9 @@ const EmailReplyResult = ({
                       <Clock className="mr-2 h-4 w-4 flex-shrink-0" />
                       <span className="mr-2 flex-shrink-0">{formatHistoryTimestamp(entry.timestamp)}</span>
                       <span className="truncate text-gray-600">
-                        {entry.response.subject || "(件名なし)"}
+                        {mode === "message"
+                          ? (entry.response.content?.substring(0, 30) + "...") || "(メッセージなし)"
+                          : (entry.response.subject || "(件名なし)")}
                       </span>
                     </div>
                     <Button
@@ -166,14 +172,16 @@ const EmailReplyResult = ({
           )}
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <label htmlFor="subject" className="block text-sm font-medium">
-                件名
-              </label>
+          {mode !== "message" && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label htmlFor="subject" className="block text-sm font-medium">
+                  件名
+                </label>
+              </div>
+              <Input id="subject" placeholder="件名がここに表示されます" readOnly className="w-full" />
             </div>
-            <Input id="subject" placeholder="件名がここに表示されます" readOnly className="w-full" />
-          </div>
+          )}
 
           <div className="space-y-2">
             <div className="flex items-center justify-between">
@@ -183,7 +191,11 @@ const EmailReplyResult = ({
             </div>
             <Textarea
               id="content"
-              placeholder="左側で情報を入力して「メール生成」ボタンを押すと、AIが生成したメール本文がここに表示されます"
+              placeholder={
+                mode === "message"
+                  ? "左側で情報を入力して「生成」ボタンを押すと、AIが生成したメッセージ本文がここに表示されます"
+                  : "左側で情報を入力して「メール生成」ボタンを押すと、AIが生成したメール本文がここに表示されます"
+              }
               readOnly
               className="min-h-[300px] w-full font-mono text-sm"
             />
@@ -208,7 +220,9 @@ const EmailReplyResult = ({
     <div className="w-full h-full">
       <Card className="w-full h-full">
         <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle className="text-xl">生成されたメール返信</CardTitle>
+          <CardTitle className="text-xl">
+            {mode === "message" ? "生成されたメッセージ返信" : "生成されたメール返信"}
+          </CardTitle>
           {history.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -231,7 +245,9 @@ const EmailReplyResult = ({
                       <Clock className="mr-2 h-4 w-4 flex-shrink-0" />
                       <span className="mr-2 flex-shrink-0">{formatHistoryTimestamp(entry.timestamp)}</span>
                       <span className="truncate text-gray-600">
-                        {entry.response.subject || "(件名なし)"}
+                        {mode === "message"
+                          ? (entry.response.content?.substring(0, 30) + "...") || "(メッセージなし)"
+                          : (entry.response.subject || "(件名なし)")}
                       </span>
                     </div>
                     <Button
@@ -252,7 +268,7 @@ const EmailReplyResult = ({
           )}
         </CardHeader>
         <CardContent className="space-y-6">
-          {subject !== undefined && (
+          {mode !== "message" && subject !== undefined && (
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <label htmlFor="subject" className="block text-sm font-medium">

--- a/src/components/EmailReplyResult.tsx
+++ b/src/components/EmailReplyResult.tsx
@@ -150,7 +150,7 @@ const EmailReplyResult = ({
                       <span className="mr-2 flex-shrink-0">{formatHistoryTimestamp(entry.timestamp)}</span>
                       <span className="truncate text-gray-600">
                         {mode === "message"
-                          ? (entry.response.content?.substring(0, 30) + "...") || "(メッセージなし)"
+                          ? (entry.response.content ? entry.response.content.substring(0, 30) + "..." : "(メッセージなし)")
                           : (entry.response.subject || "(件名なし)")}
                       </span>
                     </div>
@@ -246,7 +246,7 @@ const EmailReplyResult = ({
                       <span className="mr-2 flex-shrink-0">{formatHistoryTimestamp(entry.timestamp)}</span>
                       <span className="truncate text-gray-600">
                         {mode === "message"
-                          ? (entry.response.content?.substring(0, 30) + "...") || "(メッセージなし)"
+                          ? (entry.response.content ? entry.response.content.substring(0, 30) + "..." : "(メッセージなし)")
                           : (entry.response.subject || "(件名なし)")}
                       </span>
                     </div>

--- a/src/hooks/useEmailGeneration.ts
+++ b/src/hooks/useEmailGeneration.ts
@@ -9,6 +9,7 @@ export interface EmailFormData {
   responseOutline: string;
   tone?: number; // 0-100: 0=formal, 100=casual
   length?: number; // 0-100: 0=concise, 100=detailed
+  mode?: "email" | "message"; // Add mode for chat/message support
 }
 
 export function useEmailGeneration() {
@@ -27,6 +28,7 @@ export function useEmailGeneration() {
         style_examples: styleExamples,
         tone: formData.tone,
         length: formData.length,
+        mode: formData.mode || "email", // Pass mode to email generation
       }, apiKeys.openai);
 
       // Add additional validation to ensure content exists

--- a/src/lib/emailGeneration.ts
+++ b/src/lib/emailGeneration.ts
@@ -160,7 +160,9 @@ ${getLengthInstruction(formData.length)}
 
     // Add specific instructions based on mode
     if (isMessageMode) {
-      systemPromptContent += "\n\nチャットメッセージ返信タスク: 受信したチャットメッセージと返信概要に基づいて、SlackやChatworkなどのチャットツールに適した返信メッセージを作成してください。件名は不要で、本文のみを生成してください。自然で読みやすく、チームコミュニケーションに適したトーンで書いてください。";
+      systemPromptContent += isNewEmail
+        ? "\n\n新規メッセージ作成タスク: 返信概要に基づいて、SlackやChatworkなどのチャットツールに適したメッセージを作成してください。件名は不要で、本文のみを生成してください。自然で読みやすく、チームコミュニケーションに適したトーンで書いてください。"
+        : "\n\nチャットメッセージ返信タスク: 受信したチャットメッセージと返信概要に基づいて、SlackやChatworkなどのチャットツールに適した返信メッセージを作成してください。件名は不要で、本文のみを生成してください。自然で読みやすく、チームコミュニケーションに適したトーンで書いてください。";
     } else if (isNewEmail) {
       systemPromptContent += "\n\n新規メール作成タスク: 提供されたメール内容の概要に基づいて、適切なビジネスメールを作成してください。件名と本文の両方を生成してください。";
     } else {

--- a/src/lib/emailGeneration.ts
+++ b/src/lib/emailGeneration.ts
@@ -12,6 +12,7 @@ interface EmailGenerationRequest {
   style_examples?: string[];
   tone?: number; // 0-100: 0=formal, 100=casual
   length?: number; // 0-100: 0=concise, 100=detailed
+  mode?: "email" | "message"; // Add mode for chat/message support
 }
 
 // EmailFormData をインポート (HistoryEntry で使用)
@@ -151,11 +152,16 @@ ${getLengthInstruction(formData.length)}
       "Authorization": `Bearer ${apiKey}`
     };
 
+    // Determine mode
+    const isMessageMode = formData.mode === "message";
+
     // Construct system prompt including style examples if they exist
     let systemPromptContent = formData.systemPrompt || "You are a professional business email writer who specializes in Japanese business correspondence.";
-    
-    // Add specific instructions based on email type
-    if (isNewEmail) {
+
+    // Add specific instructions based on mode
+    if (isMessageMode) {
+      systemPromptContent += "\n\nチャットメッセージ返信タスク: 受信したチャットメッセージと返信概要に基づいて、SlackやChatworkなどのチャットツールに適した返信メッセージを作成してください。件名は不要で、本文のみを生成してください。自然で読みやすく、チームコミュニケーションに適したトーンで書いてください。";
+    } else if (isNewEmail) {
       systemPromptContent += "\n\n新規メール作成タスク: 提供されたメール内容の概要に基づいて、適切なビジネスメールを作成してください。件名と本文の両方を生成してください。";
     } else {
       systemPromptContent += "\n\nメール返信タスク: 受信したメッセージと返信概要に基づいて、適切なビジネスメール返信を作成してください。";
@@ -173,6 +179,12 @@ ${getLengthInstruction(formData.length)}
 
     // メイン処理ロジック - GPT-5 APIを使用
     headers.Authorization = `Bearer ${apiKey}`;
+
+    // Determine JSON output format based on mode
+    const jsonFormatInstruction = isMessageMode
+      ? `{\n  "content": "本文"\n}`
+      : `{\n  "subject": "件名",\n  "content": "本文"\n}`;
+
     const requestBody: GPT5ChatCompletionRequest = {
       model: formData.model || "gpt-5-mini",
       messages: [
@@ -182,7 +194,7 @@ ${getLengthInstruction(formData.length)}
         },
         {
           role: "user",
-          content: `${xmlInput}\n\n${isNewEmail ? 'メール内容' : '返信内容'}は以下のJSON形式で提供してください：\n{\n  "subject": "件名",\n  "content": "本文"\n}`
+          content: `${xmlInput}\n\n${isMessageMode ? 'メッセージ内容' : isNewEmail ? 'メール内容' : '返信内容'}は以下のJSON形式で提供してください：\n${jsonFormatInstruction}`
         }
       ],
       max_completion_tokens: 4000,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -366,6 +366,7 @@ const Index = () => {
               onHistorySelect={handleHistorySelect}
               onTextAdjustment={handleTextAdjustment}
               isAdjusting={isAdjusting}
+              mode={currentFormData?.mode || "email"}
             />
           </div>
         </div>


### PR DESCRIPTION
Issue #28 に対応しました。\n\n### 概要\nSlackやChatworkなどのチャットツール向けに、件名なしでカジュアルな返信メッセージを生成できる機能を追加しました。\n\n### 変更点\n- **EmailReplyForm**: \n  - 「メール / チャット」モードの切り替えスイッチを追加。\n  - モード設定をlocalStorageに保存するように変更。\n  - バリデーションメッセージやUIラベルをモードに応じて動的に変更。\n- **EmailReplyResult**: \n  - チャットモード時は件名入力欄を非表示に。 \n  - 生成履歴のドロップダウンにおいて、チャットモード時は件名の代わりに本文の冒頭を表示。\n  - カードタイトルをモードに応じて変更。\n- **emailGenerationロジック**: \n  - チャットモード時はシステムプロンプトをチャット向けに調整。\n  - チャットモード時はJSON出力から件名を除外。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * メール/メッセージモード切替を追加。UIのスイッチで選択可能。
  * モードに応じて表示文言・プレースホルダが切替（メールは件名＋本文、メッセージは本文のみ）。
  * 履歴表示や生成結果の見出しがモードに応じて変化し、メッセージモードでは件名欄を非表示に。
  * 選択モードはブラウザに保存され、復元されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a toggleable "メール/メッセージ" mode across form, generation, and results to support chat-style replies (no subject) in addition to business emails.
> 
> - Adds `mode` state to `EmailReplyForm` with UI switch, localStorage persistence, reset handling, and mode-aware validation/labels
> - Updates `EmailReplyResult` to hide subject in message mode, adjust titles/placeholders, and show content snippet in history
> - Extends `useEmailGeneration` and `emailGeneration` to pass `mode`, adjust system prompts per mode, and change expected JSON output shape (`content` only for message mode vs. `subject`+`content` for email)
> - Wires `mode` through `Index` to results panel
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 354c036c98c80422c777522fd5eb15cf60262b9b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->